### PR TITLE
UEFI support added

### DIFF
--- a/frzr-bootstrap
+++ b/frzr-bootstrap
@@ -39,12 +39,10 @@ fi
 mkdir -p ${MOUNT_PATH}
 
 parted --script ${DISK} \
-	mklabel efi \
-	mkpart primary fat32 1mb 512MiB
-
-parted --script ${DISK} \
 	mklabel msdos \
-	mkpart primary 1mb 100%
+	mkpart primary fat32 1MiB 512MiB \
+	set 1 esp on \
+	mkpart primary 512MiB 100%
 
 mkfs.btrfs -L frzr_root -f ${DISK}2
 mount -t btrfs -o nodatacow ${DISK}2 ${MOUNT_PATH}
@@ -59,6 +57,8 @@ mkdir ${MOUNT_PATH}/boot
 mkdir -p ${MOUNT_PATH}/etc
 mkdir -p ${MOUNT_PATH}/.etc
 
+mkfs.vfat ${DISK}1
+dosfslabel ${DISK}1 efi
 mount -t vfat ${DISK}1 ${MOUNT_PATH}/boot/
 
 # install & setup bootloader
@@ -72,5 +72,4 @@ else
 	dd bs=440 count=1 conv=notrunc if=/usr/lib/syslinux/bios/mbr.bin of=${DISK}
 fi
 
-parted ${DISK} set 1 esp on
-parted ${DISK} set 2 boot on
+parted ${DISK} set 1 boot on

--- a/frzr-bootstrap
+++ b/frzr-bootstrap
@@ -10,6 +10,8 @@ fi
 
 MOUNT_PATH=/tmp/frzr_root
 
+UEFI="-d /sys/firmware/efi/efivars"
+
 device_list=()
 device_output=`lsblk --list -n -o name,model,size,type | grep disk | tr -s ' ' '\t'`
 
@@ -37,11 +39,15 @@ fi
 mkdir -p ${MOUNT_PATH}
 
 parted --script ${DISK} \
+	mklabel efi \
+	mkpart primary fat32 1mb 512MiB
+
+parted --script ${DISK} \
 	mklabel msdos \
 	mkpart primary 1mb 100%
 
-mkfs.btrfs -L frzr_root -f ${DISK}1
-mount -t btrfs -o nodatacow ${DISK}1 ${MOUNT_PATH}
+mkfs.btrfs -L frzr_root -f ${DISK}2
+mount -t btrfs -o nodatacow ${DISK}2 ${MOUNT_PATH}
 
 btrfs subvolume create ${MOUNT_PATH}/var
 btrfs subvolume create ${MOUNT_PATH}/home
@@ -53,9 +59,18 @@ mkdir ${MOUNT_PATH}/boot
 mkdir -p ${MOUNT_PATH}/etc
 mkdir -p ${MOUNT_PATH}/.etc
 
-# install & setup bootloader
-mkdir -p ${MOUNT_PATH}/boot/syslinux
-extlinux --install ${MOUNT_PATH}/boot
-dd bs=440 count=1 conv=notrunc if=/usr/lib/syslinux/bios/mbr.bin of=${DISK}
+mount -t vfat ${DISK}1 ${MOUNT_PATH}/boot/
 
-parted ${DISK} set 1 boot on
+# install & setup bootloader
+if [ $UEFI ]; then
+	mkdir -p ${MOUNT_PATH}/boot/EFI/syslinux
+	cp -r /usr/lib/syslinux/efi64/* ${MOUNT_PATH}/boot/EFI/syslinux
+	efibootmgr --create --disk ${DISK} --part 1 --loader /EFI/syslinux/syslinux.efi --label "gamerOS" --verbose
+else
+	mkdir -p ${MOUNT_PATH}/boot/syslinux
+	extlinux --install ${MOUNT_PATH}/boot
+	dd bs=440 count=1 conv=notrunc if=/usr/lib/syslinux/bios/mbr.bin of=${DISK}
+fi
+
+parted ${DISK} set 1 esp on
+parted ${DISK} set 2 boot on

--- a/frzr-deploy
+++ b/frzr-deploy
@@ -23,6 +23,12 @@ if ! mountpoint -q ${MOUNT_PATH}; then
 	sleep 5
 fi
 
+if ! mountpoint -q ${MOUNT_PATH}/boot; then
+	mkdir -p ${MOUNT_PATH}/boot
+	mount -L efi ${MOUNT_PATH}/boot
+	sleep 5
+fi
+
 mkdir -p ${DEPLOY_PATH}
 
 # delete old deployments unless we are not currently running a frzr deployment (i.e. during install)
@@ -83,18 +89,25 @@ fi
 tar xfO ${IMG_FILE} | btrfs receive ${DEPLOY_PATH}
 cp ${SUBVOL}/boot/vmlinuz-linux ${MOUNT_PATH}/boot/
 
+# check if this is a UEFI system
+if [ -d /sys/firmware/efi/efivars ]; then
+	SYSLINUXCONF="/boot/EFI/syslinux/syslinux.cfg"
+else
+	SYSLINUXCONF="/boot/syslinux/syslinux.cfg"
+fi
+
 echo "
 default ${CHANNEL}-${VERSION}
 label ${CHANNEL}-${VERSION}
 kernel ../vmlinuz-linux
 append root=LABEL=frzr_root rw rootflags=subvol=deployments/${CHANNEL}-${VERSION} quiet
 initrd ../initramfs-linux.img
-" > ${MOUNT_PATH}/boot/syslinux/syslinux.cfg
+" > ${MOUNT_PATH}${SYSLINUXCONF}
 
 mkinitcpio -g ${MOUNT_PATH}/boot/initramfs-linux.img -k ${MOUNT_PATH}/boot/vmlinuz-linux -r ${SUBVOL} -A btrfs || true # workaround for initrd warning
 
 rm -f ${MOUNT_PATH}/*.img.tar.xz
 
-umount ${MOUNT_PATH}
+umount -R ${MOUNT_PATH}
 
 echo "deployment complete; restart to boot into ${CHANNEL}-${VERSION}"

--- a/frzr-deploy
+++ b/frzr-deploy
@@ -91,18 +91,22 @@ cp ${SUBVOL}/boot/vmlinuz-linux ${MOUNT_PATH}/boot/
 
 # check if this is a UEFI system
 if [ -d /sys/firmware/efi/efivars ]; then
-	SYSLINUXCONF="/boot/EFI/syslinux/syslinux.cfg"
+echo "
+default ${CHANNEL}-${VERSION}
+label ${CHANNEL}-${VERSION}
+kernel ../../vmlinuz-linux
+append root=LABEL=frzr_root rw rootflags=subvol=deployments/${CHANNEL}-${VERSION} quiet
+initrd ../../initramfs-linux.img
+" > ${MOUNT_PATH}/boot/EFI/syslinux/syslinux.cfg
 else
-	SYSLINUXCONF="/boot/syslinux/syslinux.cfg"
-fi
-
 echo "
 default ${CHANNEL}-${VERSION}
 label ${CHANNEL}-${VERSION}
 kernel ../vmlinuz-linux
 append root=LABEL=frzr_root rw rootflags=subvol=deployments/${CHANNEL}-${VERSION} quiet
 initrd ../initramfs-linux.img
-" > ${MOUNT_PATH}${SYSLINUXCONF}
+" > ${MOUNT_PATH}/boot/syslinux/syslinux.cfg
+fi
 
 mkinitcpio -g ${MOUNT_PATH}/boot/initramfs-linux.img -k ${MOUNT_PATH}/boot/vmlinuz-linux -r ${SUBVOL} -A btrfs || true # workaround for initrd warning
 


### PR DESCRIPTION
To be able to use this the pull request for gamer-os and install-media will need to be accepted as well. Without them gamer-os isn't able to mount the boot partition and the installer isn't able to create it.

The only change this makes to the installation on BIOS systems is that there is now a boot partition.