### PR TITLE
Bootloader no frzr kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ __Q__ Is it easy to create a proof-of-concept distro that is compatible with frz
 __A__ Absolutely: frzr wants to be hackable and easy to work with in every aspect: just create a btrfs subvolume and run your preferred command to write a rootfs (debootstrap, pacstrap or whatever). Then create a snapshot of it with btrfs send and that file can be deployed on real hardware!
 
 
-__Q__ Can a distro be shipped with its own kernel?
-
-__A__ Yes and this is the preferred method. The user can boot a deployment only if such deployment comes with its own kernel or the user has installed one
-already via the dedicated *frzr kernel* tool!
-
-
 __Q__ Are there rules to follow?
 
 __A__ There are conventions: for example a distro should __NOT__ assume it's the only distro installed, and *SHOULD NOT* cause harm to other deployments for example by writing to the efi partition.

--- a/__frzr
+++ b/__frzr
@@ -789,6 +789,8 @@ prepare_efi_partition() {
 
 	local default_config_entry=""
 
+	local default_frzr_default_entry_filename="frzr.conf"
+
 	# create /loader/entries in the EFI system partition (if it does not exists already)
 	mkdir -p ${efi_mount_path}/loader/entries
 
@@ -860,7 +862,14 @@ prepare_efi_partition() {
 						if echo "${systemd_boot_update_result}" | grep -q 'ERROR'; then
 							echo "ERROR: Could not add bootloader entry: ${systemd_boot_update_result}"
 						else
-							default_boot_cfg="${boot_entry}"
+							# Write "${EFI_MOUNT_PATH}/loader/entries/${default_frzr_default_entry_filename}" so that frzr will make use of the new kernel
+							# WARNING: btrfs_rootfs_uuid being empty means gpt-auto will be used
+							local default_boot_entry_generation_res=$(generate_systemd_boot_cfg "${version}" "${default_frzr_default_entry_filename}" "${version}" "${efi_mount_path}" "${amd_ucode}" "${intel_ucode}" "${vmlinuz_file}" "${initramfs_file}" "${additional_arguments}" "" "")
+							if echo "${boot_entry_generation_res}" | grep -Fq "ERROR"; then
+								echo "ERROR: Could not add bootloader entry: ${default_boot_entry_generation_res}"
+							else
+								default_boot_cfg="${boot_entry}"
+							fi
 						fi
 					else
 						echo "ERROR: Could not copy '${boot_dir}/${initramfs_file}' to '${efi_mount_path}/${version}/${initramfs_file}'"
@@ -872,8 +881,8 @@ prepare_efi_partition() {
 		done
 
 		# override the default deployment boot with the user-provided one
-		if [ -f "${efi_mount_path}/loader/entries/frzr_kernel.conf" ]; then
-			default_boot_cfg="frzr_kernel.conf"
+		if [ -f "${efi_mount_path}/loader/entries/${default_frzr_default_entry_filename}" ]; then
+			default_boot_cfg="${default_frzr_default_entry_filename}"
 		fi
 
 		# write the default boot entry
@@ -881,12 +890,6 @@ prepare_efi_partition() {
 			echo "ERROR: no bootable kernel found"
 		else
 			echo "default ${default_boot_cfg}" > "${efi_mount_path}/loader/loader.conf"
-
-			# If frzr-kernel has been used this is a development machine: add a boot timeout so that different kernels can be used
-			if [ "${default_boot_cfg}" = "frzr_kernel.conf" ]; then
-				echo "timeout 3" >> "${efi_mount_path}/loader/loader.conf"
-			fi
-
 			echo "OK"
 		fi
 	fi

--- a/__frzr
+++ b/__frzr
@@ -789,7 +789,7 @@ prepare_efi_partition() {
 
 	local default_config_entry=""
 
-	local default_frzr_default_entry_filename="frzr.conf"
+	local default_entry_filename="frzr.conf"
 
 	# create /loader/entries in the EFI system partition (if it does not exists already)
 	mkdir -p ${efi_mount_path}/loader/entries
@@ -862,9 +862,9 @@ prepare_efi_partition() {
 						if echo "${systemd_boot_update_result}" | grep -q 'ERROR'; then
 							echo "ERROR: Could not add bootloader entry: ${systemd_boot_update_result}"
 						else
-							# Write "${EFI_MOUNT_PATH}/loader/entries/${default_frzr_default_entry_filename}" so that frzr will make use of the new kernel
+							# Write "${EFI_MOUNT_PATH}/loader/entries/${default_entry_filename}" so that frzr will make use of the new kernel
 							# WARNING: btrfs_rootfs_uuid being empty means gpt-auto will be used
-							local default_boot_entry_generation_res=$(generate_systemd_boot_cfg "${version}" "${default_frzr_default_entry_filename}" "${version}" "${efi_mount_path}" "${amd_ucode}" "${intel_ucode}" "${vmlinuz_file}" "${initramfs_file}" "${additional_arguments}" "" "")
+							local default_boot_entry_generation_res=$(generate_systemd_boot_cfg "${version}" "${default_entry_filename}" "${version}" "${efi_mount_path}" "${amd_ucode}" "${intel_ucode}" "${vmlinuz_file}" "${initramfs_file}" "${additional_arguments}" "" "")
 							if echo "${boot_entry_generation_res}" | grep -Fq "ERROR"; then
 								echo "ERROR: Could not add bootloader entry: ${default_boot_entry_generation_res}"
 							else
@@ -881,8 +881,8 @@ prepare_efi_partition() {
 		done
 
 		# override the default deployment boot with the user-provided one
-		if [ -f "${efi_mount_path}/loader/entries/${default_frzr_default_entry_filename}" ]; then
-			default_boot_cfg="${default_frzr_default_entry_filename}"
+		if [ -f "${efi_mount_path}/loader/entries/${default_entry_filename}" ]; then
+			default_boot_cfg="${default_entry_filename}"
 		fi
 
 		# write the default boot entry

--- a/__frzr-bootloader
+++ b/__frzr-bootloader
@@ -119,10 +119,8 @@ frzr_bootloader() {
 			;;
 
 		"BOOTLOADER")
-
-			# Check if a (supported) bootloader is present and if not install it
-
-			# Install systemd-boot as the bootloader
+			# Check if a (supported) bootloader is present and if not
+			# install systemd-boot as the bootloader
 			if [ ! -f "${EFI_MOUNT_PATH}/EFI/systemd/systemd-bootx64.efi" ]; then
 				TASK_MSG="Installing systemd-boot to '${EFI_MOUNT_PATH}' as the bootloader"
 				if ! bootctl --esp-path="${EFI_MOUNT_PATH}/" install; then
@@ -164,25 +162,36 @@ frzr_bootloader() {
 				continue
 			fi
 
-			# Read additional boot arguments (to be added to the kernel cmdline) from the deployed image
+			# Initialize an empty deployment kernel cmdline
 			local deployment_arguments=""
+
+			# Read additional boot arguments (to be added to the kernel cmdline) from the deployed image
 			if [ -f "${SUBVOL}/usr/lib/frzr.d/bootconfig.conf" ]; then
-				local bootconf_args=$(cat "${SUBVOL}/usr/lib/frzr.d/bootconfig.conf") 
+				local bootconf_args=$(cat "${SUBVOL}/usr/lib/frzr.d/bootconfig.conf")
 				deployment_arguments="$deployment_arguments ${bootconf_args}"
 			else
 				TASK_WARNING=1
-				TASK_WARNING_MSG="Could not read '${SUBVOL}/usr/lib/frzr.d/bootconfig.conf': default kernel cmdline will be used"
+				TASK_WARNING_MSG="Could not read '${SUBVOL}/usr/lib/frzr.d/bootconfig.conf': skipped"
+				send_data
+			fi
+
+			# Read additional boot arguments (to be added to the kernel cmdline) from the deployed image
+			if [ -f "${SUBVOL}/etc/kernel/cmdline" ]; then
+				local kernel_cmdline_args=$(cat "${SUBVOL}/etc/kernel/cmdline")
+				deployment_arguments="$deployment_arguments ${kernel_cmdline_args}"
+			else
+				TASK_WARNING=1
+				TASK_WARNING_MSG="Could not read '${SUBVOL}/etc/kernel/cmdline': skipped"
 				send_data
 			fi
 
 			# Read additional boot arguments (to be added to the kernel cmdline) from the user file
-			local additional_arguments="$deployment_arguments"
 			if [ -f "${EFI_MOUNT_PATH}/frzr_bootconfig.conf" ]; then
-				local user_bootconf_args=$(cat "${EFI_MOUNT_PATH}/frzr_bootconfig.conf") 
-				additional_arguments="$additional_arguments ${user_bootconf_args}"
+				local user_bootconf_args=$(cat "${EFI_MOUNT_PATH}/frzr_bootconfig.conf")
+				deployment_arguments="$deployment_arguments ${user_bootconf_args}"
 			else
 				TASK_WARNING=1
-				TASK_WARNING_MSG="Could not read '${EFI_MOUNT_PATH}/frzr_bootconfig.conf': deployment cmdline will be used"
+				TASK_WARNING_MSG="Could not read '${EFI_MOUNT_PATH}/frzr_bootconfig.conf': skipped"
 				send_data
 			fi
 
@@ -196,7 +205,7 @@ frzr_bootloader() {
 			fi
 
 			# This is used to update the EFI partition: setting up systemd-boot (or whatever else bootlader might be supported) to boot the new deployment
-			local efi_update_result=$(prepare_efi_partition "${NAME}" "${EFI_MOUNT_PATH}" "${SUBVOL}/boot" "${additional_arguments}" "${rootfs_uuid}" "${rootfs_subvolid}")
+			local efi_update_result=$(prepare_efi_partition "${NAME}" "${EFI_MOUNT_PATH}" "${SUBVOL}/boot" "${deployment_arguments}" "${rootfs_uuid}" "${rootfs_subvolid}")
 			if echo "${efi_update_result}" | grep -q 'ERROR'; then
 				# bootloader configuration could not be updated
 				TASK_ERROR=1
@@ -221,6 +230,7 @@ frzr_bootloader() {
 
 			RUNNING=false
 			;;
+
 		"FAIL")
 			# This state should only be used if the unlock failed
 
@@ -231,6 +241,7 @@ frzr_bootloader() {
 			send_data
 			RUNNING=false
 			;;
+
 		*)
 			TASK_STATE="UNKNOWN_ERROR"
 
@@ -239,6 +250,7 @@ frzr_bootloader() {
 			send_data
 			RUNNING=false
 			;;
+
 		esac
 	done
 

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -512,20 +512,6 @@ frzr_deploy() {
 			TASK_STATE="CLEANUP"
 			send_data
 
-			# This is used to update the EFI partition: setting up systemd-boot (or whatever else bootlader might be supported) to boot the new deployment
-			local efi_update_result=$("${BASH_SOURCE%/*}/frzr-bootloader" "${NAME}")
-			if echo "${efi_update_result}" | grep -Fq 'ERROR'; then
-				# bootloader configuration could not be updated
-				TASK_ERROR=1
-				TASK_ERROR_MSG="Could not update the EFI partition: ${efi_update_result}"
-				STATE="FAIL"
-				send_data
-				continue
-			fi
-
-			# Remove download artifacts (if any)
-			rm -f ${MOUNT_PATH}/*.img.*
-
 			# Lazy umount the deployed system (find all mounted subdirectories under the parent directory and unmount the mounted subdirectories)
 			TASK_MSG="Post-install umount of '${SUBVOL}'"
 			send_data
@@ -556,6 +542,17 @@ frzr_deploy() {
 				continue
 			fi
 
+			# This is used to update the EFI partition: setting up systemd-boot (or whatever else bootlader might be supported) to boot the new deployment
+			local efi_update_result=$("${BASH_SOURCE%/*}/frzr-bootloader" "${NAME}")
+			if echo "${efi_update_result}" | grep -Fq 'ERROR'; then
+				# bootloader configuration could not be updated
+				TASK_ERROR=1
+				TASK_ERROR_MSG="Could not update the EFI partition: ${efi_update_result}"
+				STATE="FAIL"
+				send_data
+				continue
+			fi
+
 			# Activates the new deployed image by making it the default btrfs subvolume
 			# systemd-equipped initramfs images will automount the default subvolume as the rootfs
 			TASK_MSG="Activating the new deployment (subvolid=${subvolid}) as the default subvolume"
@@ -567,7 +564,10 @@ frzr_deploy() {
 				send_data
 				continue
 			fi
-			
+
+			# Remove download artifacts (if any)
+			rm -f "${MOUNT_PATH}"/*.img*
+
 			STATE="SUCCESS"
 			;;
 		"SUCCESS")


### PR DESCRIPTION
The tool frzr kernel has been removed: clean up the rest of the code to remove references to it.

Add a default boot entry (called frzr.conf, same as the pre-refactor) that will use gpt-auto feature to boot the default deployment.